### PR TITLE
[veil] update gemspec, small file permissions addition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     veil (0.1.0)
-      bcrypt
+      bcrypt (~> 3.1)
       pbkdf2
 
 GEM
@@ -60,4 +60,4 @@ DEPENDENCIES
   veil!
 
 BUNDLED WITH
-   1.11.2
+   1.13.6

--- a/lib/veil/credential_collection/chef_secrets_file.rb
+++ b/lib/veil/credential_collection/chef_secrets_file.rb
@@ -33,8 +33,8 @@ module Veil
       #   a hash of options to pass to the constructor
       def initialize(opts = {})
         @path    = (opts[:path] && File.expand_path(opts[:path])) || "/etc/opscode/private-chef-secrets.json"
-        @user    = opts[:user]
-        @group   = opts[:group]
+        @user    = opts[:user]    || 'root'
+        @group   = opts[:group]   || 'root'
         @version = opts[:version] || 1
         super(opts)
       end

--- a/lib/veil/credential_collection/chef_secrets_file.rb
+++ b/lib/veil/credential_collection/chef_secrets_file.rb
@@ -1,6 +1,7 @@
 require "veil/credential_collection/base"
 require "fileutils"
 require "json"
+require "tempfile"
 
 module Veil
   class CredentialCollection
@@ -24,14 +25,16 @@ module Veil
         end
       end
 
-      attr_reader :path
+      attr_reader :path, :user, :group
 
       # Create a new ChefSecretsFile
       #
       # @param [Hash] opts
       #   a hash of options to pass to the constructor
       def initialize(opts = {})
-        @path = (opts[:path] && File.expand_path(opts[:path])) || "/etc/opscode/private-chef-secrets.json"
+        @path    = (opts[:path] && File.expand_path(opts[:path])) || "/etc/opscode/private-chef-secrets.json"
+        @user    = opts[:user]
+        @group   = opts[:group]
         @version = opts[:version] || 1
         super(opts)
       end
@@ -47,7 +50,14 @@ module Veil
       # Save the CredentialCollection to file
       def save
         FileUtils.mkdir_p(File.dirname(path)) unless File.directory?(File.dirname(path))
-        File.open(path, "w+") { |f| f.puts(JSON.pretty_generate(secrets_hash)) }
+
+        f = Tempfile.new("veil") # defaults to mode 0600
+        FileUtils.chown(user, group, f.path)
+        f.puts(JSON.pretty_generate(secrets_hash))
+        f.flush
+        f.close
+
+        FileUtils.mv(f.path, path)
         true
       end
 

--- a/veil.gemspec
+++ b/veil.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "veil/version"
-require "find"
 
 Gem::Specification.new do |spec|
   spec.name          = "veil"
@@ -15,12 +14,12 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.homepage      = "https://github.com/chef/chef-server/"
 
-  spec.files         = Find.find("./").select { |f| !File.directory?(f) }
+  spec.files         = Dir.glob("{bin,lib,spec}/**/*").reject { |f| File.directory?(f) } + ["LICENSE"]
   spec.executables   = spec.files.grep(/^bin/) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)/)
+  spec.test_files    = spec.files.grep(/^(spec|features)/)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bcrypt"
+  spec.add_dependency "bcrypt", "~> 3.1"
   spec.add_dependency "pbkdf2"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
If both `user` and `group` are set, the file will be given those
permissions (before being written to).

Also changes the write behaviour to first write to a newly created temp
file (mode 0600), and the moves the file in place when writing has
finished.