### PR TITLE
Add #get to Veil::CredentialCollection::Base

### DIFF
--- a/lib/veil/credential_collection/base.rb
+++ b/lib/veil/credential_collection/base.rb
@@ -49,6 +49,42 @@ module Veil
         end
       end
 
+      #
+      # Retrieves a credential from the credential store:
+      #
+      #  get(name)
+      #  get(group, name)
+      #
+      def get(*args)
+        case args.length
+        when 1
+          cred_name = args[0]
+          c = credentials[cred_name]
+          if c.nil?
+            raise Veil::CredentialNotFound, "Credential '#{cred_name}' not found."
+          else
+            c.value
+          end
+        when 2
+          group_name = args[0]
+          cred_name = args[1]
+
+          g = credentials[args[0]]
+          if g.nil?
+            raise Veil::GroupNotFound, "Credential group '#{group_name}' not found."
+          else
+            c = g[args[1]]
+            if c.nil?
+              raise Veil::CredentialNotFound, "Credential '#{cred_name}' not found in group '#{group_name}'."
+            else
+              c.value
+            end
+          end
+        else
+          raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1 or 2)"
+        end
+      end
+
       # Add a new credential to the credentials
       #
       # @param [Hash] args

--- a/lib/veil/exceptions.rb
+++ b/lib/veil/exceptions.rb
@@ -7,4 +7,6 @@ module Veil
   class MissingParameter < StandardError; end
   class NotImplmented < StandardError; end
   class InvalidCredentialHash < StandardError; end
+  class CredentialNotFound < StandardError; end
+  class GroupNotFound < StandardError; end
 end

--- a/spec/credential_collection/base_spec.rb
+++ b/spec/credential_collection/base_spec.rb
@@ -44,6 +44,37 @@ describe Veil::CredentialCollection::Base do
     end
   end
 
+  describe "#get" do
+    before do
+      subject.add("testkey0", value: "testvalue0")
+      subject.add("testgroup", "testkey1", value: "testvalue1")
+    end
+
+    it "returns the value of a given credential" do
+      expect(subject.get("testkey0")).to eq("testvalue0")
+    end
+
+    it "returns the value of a given credential in a group" do
+      expect(subject.get("testgroup", "testkey1")).to eq("testvalue1")
+    end
+
+    it "raises an error if the credential isn't found" do
+      expect { subject.get("dne") }.to raise_error(Veil::CredentialNotFound)
+    end
+
+    it "raises an error if the group isn't found" do
+      expect { subject.get("dne", "tesetkey") }.to raise_error(Veil::GroupNotFound)
+    end
+
+    it "raises an error if the credential isn't found in the group" do
+      expect { subject.get("testgroup", "dne") }.to raise_error(Veil::CredentialNotFound)
+    end
+
+    it "raises an error if the wrong number of arguments are given" do
+      expect { subject.get("testgroup", "tesetkey", "whoops") }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#add" do
     it "creates a new credential" do
       subject.add("cowabunga")


### PR DESCRIPTION
This will help make accessing credentials in cookbooks a little bit
easier so we don't have to remember to call #value on the return.

Signed-off-by: Steven Danna <steve@chef.io>