### PR TITLE
Add `exist?` method  to CredentialCollection

### DIFF
--- a/lib/veil/credential_collection/base.rb
+++ b/lib/veil/credential_collection/base.rb
@@ -69,11 +69,11 @@ module Veil
           group_name = args[0]
           cred_name = args[1]
 
-          g = credentials[args[0]]
+          g = credentials[group_name]
           if g.nil?
             raise Veil::GroupNotFound, "Credential group '#{group_name}' not found."
           else
-            c = g[args[1]]
+            c = g[cred_name]
             if c.nil?
               raise Veil::CredentialNotFound, "Credential '#{cred_name}' not found in group '#{group_name}'."
             else
@@ -83,6 +83,16 @@ module Veil
         else
           raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 1 or 2)"
         end
+      end
+
+      #
+      # Check to see if a given credential has been added.
+      #
+      def exist?(*args)
+        get(*args)
+        true
+      rescue Veil::GroupNotFound, Veil::CredentialNotFound
+        false
       end
 
       # Add a new credential to the credentials

--- a/spec/credential_collection/base_spec.rb
+++ b/spec/credential_collection/base_spec.rb
@@ -44,6 +44,7 @@ describe Veil::CredentialCollection::Base do
     end
   end
 
+
   describe "#get" do
     before do
       subject.add("testkey0", value: "testvalue0")
@@ -72,6 +73,17 @@ describe Veil::CredentialCollection::Base do
 
     it "raises an error if the wrong number of arguments are given" do
       expect { subject.get("testgroup", "tesetkey", "whoops") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#exist?" do
+    it "returns false if the key does not exist" do
+      expect(subject.exist?("Invalid Key")).to eq(false)
+    end
+
+    it "returns true if the key does exist" do
+      subject.add("testkey0", value: "testvalue0")
+      expect(subject.exist?("testkey0")).to eq(true)
     end
   end
 


### PR DESCRIPTION
THis is needed for the current state of Chef Server bootstrap, which
needs to know if specific keys have been stored.  Just a thin wrapper to 
look up a key and return without error whether or not the key exists. 