### PR TITLE
add bin/veil-ingest-secret

### DIFF
--- a/bin/veil-ingest-secret
+++ b/bin/veil-ingest-secret
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+require 'veil'
+require 'json'
+require 'optparse'
+
+OptionParser.new do |opts|
+  opts.banner = <<EOF
+Usage: veil-ingest-secret [options] [SECTION.]NAME
+
+Manually add secrets to a secrets provider. This is configured via environment
+variables:
+
+  * PROVIDER=chef-secrets-file       Secrets provider to use
+  * PROVIDER_CONFIG                  Configuration for the secrets provider (JSON)
+                                     - defaults differ according to providers
+
+  Options:
+EOF
+
+  opts.on("--[no-]debug", "Emit diagnostic messages.  This will print secrets. Do not use this in production") do |d|
+    options[:debug] = d
+  end
+end.parse!
+
+config = JSON.parse(ENV['PROVIDER_CONFIG'] || "{}", symbolize_names: true)
+config[:provider] = ENV['PROVIDER'] || 'chef-secrets-file'
+STDERR.puts "Using config #{config}" if options[:debug]
+
+veil = Veil::CredentialCollection.from_config(config)
+
+secret = ARGV.first
+veil_args = secret.split(".")
+STDERR.puts "veil_args = #{veil_args}" if options[:debug]
+
+STDERR.puts "Reading from stdin" if options[:debug]
+value = STDIN.read.chomp
+
+veil.add(*veil_args, value: value, frozen: true, force: true)
+veil.save

--- a/lib/veil/credential_collection.rb
+++ b/lib/veil/credential_collection.rb
@@ -1,2 +1,18 @@
 require "veil/credential_collection/base"
 require "veil/credential_collection/chef_secrets_file"
+
+module Veil
+  class CredentialCollection
+
+    def self.from_config(opts)
+      klass = case opts[:provider]
+              when 'chef-secrets-file'
+                ChefSecretsFile
+              else
+                raise UnknownProvider, "Unknown provider: #{opts[:provider]}"
+              end
+
+      klass.new(opts)
+    end
+  end
+end

--- a/lib/veil/credential_collection/base.rb
+++ b/lib/veil/credential_collection/base.rb
@@ -104,7 +104,7 @@ module Veil
       # @param [Hash] args
       #
       def add(*args)
-        params = { name: nil, group: nil, length: 128, value: nil }
+        params = { name: nil, group: nil, length: 128, value: nil, force: false }
         case args.length
         when 1
           # add('foo')
@@ -139,11 +139,11 @@ module Veil
         if params[:group]
           credentials[params[:group]] ||= {}
 
-          return credentials[params[:group]][params[:name]] if credentials[params[:group]].key?(params[:name])
+          return credentials[params[:group]][params[:name]] if credentials[params[:group]].key?(params[:name]) && !params[:force]
 
           credentials[params[:group]][params[:name]] = Veil::Credential.new(params)
         else
-          return credentials[params[:name]] if credentials.key?(params[:name])
+          return credentials[params[:name]] if credentials.key?(params[:name]) && !params[:force]
 
           credentials[params[:name]] = Veil::Credential.new(params)
         end

--- a/lib/veil/credential_collection/chef_secrets_file.rb
+++ b/lib/veil/credential_collection/chef_secrets_file.rb
@@ -26,6 +26,7 @@ module Veil
         @path = (opts[:path] && File.expand_path(opts[:path])) || "/etc/opscode/private-chef-secrets.json"
 
         import_existing = File.exists?(path) && (File.size(path) != 0)
+        legacy = true
 
         if import_existing
           begin
@@ -36,6 +37,7 @@ module Veil
 
           if hash.key?(:veil) && hash[:veil][:type] == "Veil::CredentialCollection::ChefSecretsFile"
             opts = Veil::Utils.symbolize_keys(hash[:veil]).merge(opts)
+            legacy = false
           end
         end
 
@@ -44,7 +46,7 @@ module Veil
         @version = opts[:version] || 1
         super(opts)
 
-        import_legacy_credentials(hash) if import_existing
+        import_legacy_credentials(hash) if import_existing && legacy
       end
 
       # Set the secrets file path

--- a/lib/veil/exceptions.rb
+++ b/lib/veil/exceptions.rb
@@ -11,4 +11,5 @@ module Veil
   class GroupNotFound < StandardError; end
   class FileNotFound < StandardError; end
   class FileNotReadable < StandardError; end
+  class UnknownProvider < StandardError; end
 end

--- a/spec/credential_collection/base_spec.rb
+++ b/spec/credential_collection/base_spec.rb
@@ -190,7 +190,7 @@ describe Veil::CredentialCollection::Base do
       it "does not overwrite it" do
         subject.add("my_db", "password", length: 15)
         val = subject["my_db"]["password"].value
-        subject.add("my_db", "password")
+        subject.add("my_db", "password", value: "new-password")
         expect(subject["my_db"]["password"].value).to eq(val)
       end
 
@@ -198,6 +198,19 @@ describe Veil::CredentialCollection::Base do
         subject.add("my_db", "password", length: 15)
         my_db = subject["my_db"]["password"]
         expect(subject.add("my_db", "password")).to eq(my_db)
+      end
+
+      context "when force: true is given as param" do
+        it "does overwrite it" do
+          subject.add("my_db", "password", length: 15)
+          subject.add("my_db", "password", value: 'new-password', force: true)
+          expect(subject["my_db"]["password"].value).to eq("new-password")
+        end
+
+        it "returns the new credential" do
+          subject.add("my_db", "password", length: 15)
+          expect(subject.add("my_db", "password", value: "new-password", force: true).value).to eq('new-password')
+        end
       end
     end
   end

--- a/spec/credential_collection_spec.rb
+++ b/spec/credential_collection_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+describe Veil::CredentialCollection do
+  describe 'from_config' do
+    context 'passing provider "chef-secrets-file"' do
+      let(:opts) { { provider: 'chef-secrets-file', something_else: 'config' } }
+
+      it 'instantiates ChefSecretsFile with all options' do
+        expect(Veil::CredentialCollection::ChefSecretsFile).to receive(:new).with(opts)
+        described_class.from_config(opts)
+      end
+    end
+
+    context 'passing anything else as provider' do
+      let(:opts) { { provider: 'vault' } }
+
+      it 'raises an exception' do
+        expect { described_class.from_config(opts) }.to raise_error(Veil::UnknownProvider)
+      end
+    end
+
+    context 'passing an options hash that has no provider' do
+      let(:opts) { { something: 'else' } }
+
+      it 'raises an exception' do
+        expect { described_class.from_config(opts) }.to raise_error(Veil::UnknownProvider)
+      end
+    end
+  end
+end


### PR DESCRIPTION

    For super-simple secret ingestion. Reads from stdin. Always freezes.

    Also:

      * allow for passing `force: true` to veil.add

    Note that it will be the responsibility of the command wrapping this one
    (probably a ctl-command) to suppress the local terminal echo when the
    input is read from an interactive tty.