### PR TITLE
Add FD provider to share secrets with applications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ branches:
 
 language: erlang
 otp_release:
-  - 19.1
+  - 19.3
   - 18.3
-  - 17.4
-  - R16B03-1
 install:
   - travis_retry rvm use 2.2.6 --install --binary --fuzzy
   - make install

--- a/bin/veil-env-helper
+++ b/bin/veil-env-helper
@@ -7,6 +7,7 @@ require 'optparse'
 options = {
   secrets_file: "/etc/opscode/private-chef-secrets.json",
   pack: false,
+  use_file: false,
   debug: false,
   secrets: [],
   optional_secrets: []
@@ -21,6 +22,10 @@ OptionParser.new do |opts|
 
   opts.on("--pack", "Pass secrets in a single CHEF_SECRETS_DATA environment variable") do |p|
     options[:pack] = p
+  end
+
+  opts.on("--use-file", "Pass secrets via a unlinked file available at the FD specified in CHEF_SECRETS_FD") do |fd|
+    options[:use_file] = fd
   end
 
   opts.on("-s SECRET_SPEC", "--secret SECRET_SPEC", "Secret to put in the environment") do |spec|
@@ -68,7 +73,7 @@ secrets.each do |secret|
     next
   end
 
-  if options[:pack]
+  if options[:pack] || options[:use_file]
     STDERR.puts "Packing data using #{veil_args.inspect} and #{secret_value}" if options[:debug]
     if veil_args.length == 2
       packed_data[veil_args[0]] ||= {}
@@ -84,8 +89,16 @@ secrets.each do |secret|
   end
 end
 
-if options[:pack]
+if options[:pack] && !options[:use_file]
   ENV['CHEF_SECRETS_DATA'] = packed_data.to_json
 end
 
-exec(*ARGV)
+if options[:use_file]
+  rd, wd = IO.pipe
+  wd.puts packed_data.to_json
+  wd.close
+  rd.close_on_exec = false
+  ENV['CHEF_SECRETS_FD'] = rd.to_i.to_s
+end
+
+exec(*ARGV, close_others: false)

--- a/lib/veil/credential_collection.rb
+++ b/lib/veil/credential_collection.rb
@@ -1,4 +1,5 @@
 require "veil/credential_collection/base"
+require "veil/credential_collection/chef_secrets_fd"
 require "veil/credential_collection/chef_secrets_file"
 require "veil/credential_collection/chef_secrets_env"
 
@@ -11,6 +12,8 @@ module Veil
                 ChefSecretsFile
               when 'chef-secrets-env'
                 ChefSecretsEnv
+              when 'chef-secrets-fd'
+                ChefSecretsFd
               else
                 raise UnknownProvider, "Unknown provider: #{opts[:provider]}"
               end

--- a/lib/veil/credential_collection/chef_secrets_fd.rb
+++ b/lib/veil/credential_collection/chef_secrets_fd.rb
@@ -1,0 +1,57 @@
+require "veil/exceptions"
+require "veil/credential_collection/base"
+require "json"
+
+module Veil
+  class CredentialCollection
+    class ChefSecretsFd < Base
+
+      # Create a new ChefSecretsFd
+      #
+      # @param [Hash] opts
+      #   ignored
+      def initialize(opts = {})
+        @credentials = {}
+        import_credentials_hash(inflate_secrets_from_fd)
+      end
+
+      # Unsupported methods
+      def rotate
+        raise NotImplementedError
+      end
+      alias_method :rotate_credentials, :rotate
+      alias_method :save, :rotate
+
+      def inflate_secrets_from_fd
+        if ENV['CHEF_SECRETS_FD'].nil?
+          raise InvalidCredentialCollectionFd.new("CHEF_SECRETS_FD not found in environment")
+        end
+
+        fd = ENV['CHEF_SECRETS_FD'].to_i
+        value = nil
+
+        begin
+          file = IO.new(fd, "r")
+          value = file.gets
+        rescue StandardError => e
+          msg = "A problem occured trying to read passed file descriptor: #{e}"
+          raise InvalidCredentialCollectionFd.new(msg)
+        ensure
+          file.close if file
+        end
+
+        if !value
+          msg = "File at CHEF_SECRETS_FD (#{fd}) did not contain any data!"
+          raise InvalidCredentialCollectionFd.new(msg)
+        end
+
+        begin
+          JSON.parse(value)
+        rescue JSON::ParserError => e
+          msg = "Chef secrets data could not be parsed: #{e.message}"
+          raise InvalidCredentialCollectionFd.new(msg)
+        end
+      end
+    end
+  end
+end

--- a/lib/veil/exceptions.rb
+++ b/lib/veil/exceptions.rb
@@ -6,6 +6,7 @@ module Veil
   class InvalidCredentialCollection < StandardError; end
   class InvalidCredentialCollectionFile < InvalidCredentialCollection; end
   class InvalidCredentialCollectionEnv <  InvalidCredentialCollection; end
+  class InvalidCredentialCollectionFd <  InvalidCredentialCollection; end
   class MissingParameter < StandardError; end
   class NotImplmented < StandardError; end
   class InvalidCredentialHash < StandardError; end

--- a/spec/credential_collection/chef_secrets_fd_spec.rb
+++ b/spec/credential_collection/chef_secrets_fd_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe Veil::CredentialCollection::ChefSecretsFd do
+  describe "#new" do
+    let(:content) { '{ "secret_service": { "secret_name": "secret_value" } }' }
+    let(:content_file) {
+      rd, wr = IO.pipe
+      wr.puts content
+      wr.close
+      rd
+    }
+
+    context "env variable is set" do
+      before(:each) do
+        ENV['CHEF_SECRETS_FD'] = content_file.to_i.to_s
+      end
+
+      it 'reads the secret from the passed file descriptor' do
+        expect(subject.get("secret_service", "secret_name")).to eq("secret_value")
+      end
+
+      # TODO(ssd) 2017-03-22: We wanted a test for closing the FD, but
+      # didn't want to fight with ruby today.
+
+      context "env var content cannot be parsed" do
+        let(:content) { '{ "secre ' }
+
+        it "re-raises the JSON parse error" do
+          expect{ subject.get("secret_service", "secret_name") }.to raise_error(Veil::InvalidCredentialCollectionFd)
+        end
+      end
+    end
+
+    context "CHEF_SECRETS_FD is not set" do
+      before(:each) do
+        ENV.delete('CHEF_SECRETS_FD')
+      end
+
+      it 'raises an exception' do
+        expect{ described_class.new }.to raise_error(Veil::InvalidCredentialCollectionFd)
+      end
+    end
+
+    context "unsupported methods" do
+      let(:content) { '{}' }
+
+      before(:each) do
+        ENV['CHEF_SECRETS_FD'] = content_file.to_i.to_s
+      end
+
+      it 'does not support #rotate' do
+        expect{ subject.rotate }.to raise_error(NotImplementedError)
+      end
+
+      it 'does not support #save' do
+        expect{ subject.save }.to raise_error(NotImplementedError)
+      end
+
+      it 'does not support #rotate_hasher' do
+        expect{ subject.rotate_hasher }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end

--- a/src/chef_secrets_fd.erl
+++ b/src/chef_secrets_fd.erl
@@ -1,0 +1,37 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2017, Chef Software, Inc
+%%% @doc
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+-module(chef_secrets_fd).
+
+-export([read/1]).
+
+read(_Config) ->
+    case os:getenv("CHEF_SECRETS_FD") of
+        false ->
+            lager:error("Could not find CHEF_SECRETS_FD in environment", []),
+            {error, env_var_not_found};
+        Value ->
+            Fd = erlang:list_to_integer(Value),
+            lager:info("Reading secrets from file descriptor ~B", [Fd]),
+            {ok, Content} = read_content(Fd),
+            {ok, jiffy:decode(Content)}
+    end.
+
+read_content(Fd) ->
+    Port = erlang:open_port({fd, Fd, Fd}, [binary, in, eof]),
+    gather_data(Port, []).
+
+gather_data(Port, Acc) ->
+    receive
+        {Port, eof} ->
+            erlang:port_close(Port),
+            {ok, erlang:iolist_to_binary(lists:reverse(Acc))};
+        {Port, {data, Data}} ->
+            gather_data(Port, [Data | Acc])
+    after 2000 ->
+        lager:error("timed out reading from fd"),
+        {error, timeout}
+    end.

--- a/test/chef_secrets_fd_tests.erl
+++ b/test/chef_secrets_fd_tests.erl
@@ -1,0 +1,26 @@
+-module(chef_secrets_fd_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all]).
+
+read_returns_an_error_if_var_does_exist_test() ->
+    os:unsetenv("CHEF_SECRETS_FD"),
+    ActualReturn = chef_secrets_fd:read([{}]),
+    ?assertEqual({error, env_var_not_found}, ActualReturn).
+
+read_returns_ejson_read_from_fd_referenced_in_env_var_test() ->
+    Path = filename:join([code:priv_dir(chef_secrets), "../test/json_secrets_file.json"]),
+    CredJson = os:cmd(io_lib:format("veil-dump-secrets ~s", [Path])),
+    Fd = get_fd_from_content(CredJson),
+    os:putenv("CHEF_SECRETS_FD", erlang:integer_to_list(Fd)),
+    {ok, Ejson} = chef_secrets_fd:read([]),
+    Actual = ej:get([<<"postgresql">>, <<"db_superuser_password">>], Ejson),
+    ?assertMatch(<<"37f5c43dd8b", _/binary>>, Actual),
+    os:unsetenv("CHEF_SECRETS_FD").
+
+get_fd_from_content(Data) ->
+    {A, B, C} = erlang:timestamp(),
+    TmpFile = io_lib:format("/tmp/chef_secrets~w~w~w", [A, B, C]),
+    ok = file:write_file(TmpFile, Data),
+    {ok, {file_descriptor, _, {_Port, Fd}}} = file:open(TmpFile, [read, raw]),
+    Fd.


### PR DESCRIPTION
The unsetenv in the env provider isn't enough to clear the environment out of the procfs.  It appears to do that you need to explicitly overwrite the bits of memory that compose the environment.

As an alternative to that, this PR implements a simple file descriptor passing approach where the helper puts all of the secrets into pipe and gives the application the read end.

The erlang and ruby client libraries have been updated with providers that can read from the passed FD.