### PR TITLE
Change homepage from chef server to chef secrets

### DIFF
--- a/veil.gemspec
+++ b/veil.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Veil is a Ruby Gem for generating secure secrets from a shared secret}
   spec.description   = spec.summary
   spec.license       = "Apache-2.0"
-  spec.homepage      = "https://github.com/chef/chef-server/"
+  spec.homepage      = "https://github.com/chef/chef_secrets/"
 
   spec.files         = Dir.glob("{bin,lib,spec}/**/*").reject { |f| File.directory?(f) } + ["LICENSE"]
   spec.executables   = spec.files.grep(/^bin/) { |f| File.basename(f) }


### PR DESCRIPTION
Hit a dead end trying to trace back from the page on [rubygems.org](https://rubygems.org/gems/veil) after unsuccessfully trying to find a "veil" project repository directly on GitHub.