### PR TITLE
Add some specs to chef_secrets[_keyring]

### DIFF
--- a/src/chef_secrets.erl
+++ b/src/chef_secrets.erl
@@ -3,13 +3,14 @@
          get/1,
          get/2]).
 
--type secret() :: ej:json_term().
+-type secret_value() :: ej:json_term().
+-type secret()       :: binary().
 
--spec get(binary()) -> {ok, secret()} | {error, any()}.
+-spec get(binary()) -> {ok, secret_value()} | {error, not_found}.
 get(ServiceName) ->
     chef_secrets_keyring:get(ServiceName).
 
--spec get(binary(), binary()) -> {ok, secret()} | {error, any()}.
+-spec get(binary(), binary()) -> {ok, secret()} | {error, not_found}.
 get(ServiceName, ItemName) ->
     case chef_secrets_keyring:get(ServiceName) of
         {ok, ServiceData} ->

--- a/src/chef_secrets_keyring.erl
+++ b/src/chef_secrets_keyring.erl
@@ -27,9 +27,11 @@
 start_link(Config) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
 
+-spec get(binary()) -> {ok, ej:json_term()} | {error, not_found}.
 get(Name) when is_binary(Name) ->
     gen_server:call(?MODULE, {get, Name}).
 
+-spec dump() -> ej:json_object().
 dump() ->
     gen_server:call(?MODULE, dump).
 


### PR DESCRIPTION
I'm not sure about the specs on the `gen_server`, I don't believe this is something I have seen all too often, at least not in our code base... but my impression could be mistaken and also it doesn't seem wrong to have those...