### PR TITLE
Update travis to test more erlang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ branches:
 
 language: erlang
 otp_release:
+  - 21.0
+  - 20.3
   - 19.3
   - 18.3
 install:

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,10 @@
-{erl_opts, [debug_info,
+{erl_opts, [
+            debug_info,
             warnings_as_errors,
-            {parse_transform, lager_transform}
+            {parse_transform, lager_transform},
+            {platform_define, "^(2[1-9])", open_returns_map}
            ]}.
+
 {deps, [
         {lager, {git, "https://github.com/basho/lager.git", {branch, "master"}}},
         {ej, {git, "https://github.com/seth/ej.git", {branch, "master"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,14 @@
         {jiffy, {git, "https://github.com/davisp/jiffy.git", {branch, "master"}}}
        ]}.
 
+{profiles, [
+    {test, [
+            {erl_opts, [nowarn_export_all]}
+           ]}
+]}.
+
+
+
 %% Xref
 {xref_warnings, false}.
 {xref_checks, [undefined_function_calls,

--- a/test/chef_secrets_fd_tests.erl
+++ b/test/chef_secrets_fd_tests.erl
@@ -8,19 +8,65 @@ read_returns_an_error_if_var_does_exist_test() ->
     ActualReturn = chef_secrets_fd:read([{}]),
     ?assertEqual({error, env_var_not_found}, ActualReturn).
 
+%%
+%% Note: The workaround we use for the OTP21 changes only works on linux, because it uses /proc. Expect this test to fail
+%% on other operating systems.
+%%
 read_returns_ejson_read_from_fd_referenced_in_env_var_test() ->
     Path = filename:join([code:priv_dir(chef_secrets), "../test/json_secrets_file.json"]),
     CredJson = os:cmd(io_lib:format("veil-dump-secrets ~s", [Path])),
-    Fd = get_fd_from_content(CredJson),
+    %% Note: OTP 21 detects leaked filehandles and GC's them fast, so we must hang onto the Fh for the duration of the test
+    {Fh, Fd} = get_fd_from_content(CredJson),
     os:putenv("CHEF_SECRETS_FD", erlang:integer_to_list(Fd)),
     {ok, Ejson} = chef_secrets_fd:read([]),
     Actual = ej:get([<<"postgresql">>, <<"db_superuser_password">>], Ejson),
     ?assertMatch(<<"37f5c43dd8b", _/binary>>, Actual),
-    os:unsetenv("CHEF_SECRETS_FD").
+    os:unsetenv("CHEF_SECRETS_FD"),
+    file:close(Fh).
 
 get_fd_from_content(Data) ->
     {A, B, C} = erlang:timestamp(),
     TmpFile = io_lib:format("/tmp/chef_secrets~w~w~w", [A, B, C]),
     ok = file:write_file(TmpFile, Data),
-    {ok, {file_descriptor, _, {_Port, Fd}}} = file:open(TmpFile, [read, raw]),
+    {ok, IoDevice} = file:open(TmpFile, [read, raw]),
+    Fd = get_fd_from_io_device(TmpFile, IoDevice),
+    {IoDevice, Fd}.
+
+
+-ifdef(open_returns_map).
+get_fd_from_io_device(Name, _) ->
+    %% I am ashamed of this hack.  The problem is that OTP-21 rewrote
+    %% raw files to use a nif. This has the effect of burying the file
+    %% descriptor deep in an opaque reference, and I've not spotted a
+    %% sane way to extract that info.
+    %% So the hack relies on exploiting linux process info to find our fd.
+    FName = lists:flatten(Name),
+    Fd = find_fd_for_target(FName),
     Fd.
+-else.
+get_fd_from_io_device(_, IoDevice) ->
+    %% Somewhat fragile parsing of erlang internal structures, works only in OTP < 21
+    {file_descriptor, _, {_Port, Fd}} = IoDevice,
+    Fd.
+-endif.
+
+
+-define(PROCDIR, "/proc/self/fd").
+get_filedesc_target(Fd) ->
+    case file:read_link(filename:join(?PROCDIR,Fd)) of
+        {ok, Name} ->
+            Name;
+        {error, Error} ->
+            Error
+    end.
+
+find_fd_for_target(Target) ->
+    {ok, Files} = file:list_dir(?PROCDIR),
+    %% lists:reverse is a hack to get the most recently opened
+    %% filehandle assuming the numbers are increasing. Not really
+    %% trustworthy, since the strategy is first-avail.
+    [H|_] = lists:filter(fun(F) ->
+                                 Target == get_filedesc_target(F)
+                         end,
+                         lists:reverse(Files)),
+    erlang:list_to_integer(H).


### PR DESCRIPTION
Supporting OTP-21 took a little bit of work. 

Our tests didn't survive the OTP-21 improvements.
    
We relied on some non-portable behavior to create a file, and get the
filehandle to pass to chef-secrets. This broke.
    
First of all. OTP-21 rewrote raw files to use a nif. This has the
effect of burying the file descriptor deep in an opaque reference, and
I've not spotted a sane way to extract that info. So we dive into the
proc filesystem to find the filehandle corresponding to the file we
just opened.
   
Second, we technically were leaking the filehandle; we never used it
after open, and OTP-21's GC found and cleaned it up too quickly for
the test.
    
Signed-off-by: Mark Anderson <mark@chef.io>