### PR TITLE
Fix chef_secrets_sqerl:config to call sqerl_config_env:config and onl…

### DIFF
--- a/src/chef_secrets_sqerl.erl
+++ b/src/chef_secrets_sqerl.erl
@@ -10,5 +10,18 @@
 
 -spec config({binary(), binary()}) -> proplists:proplist().
 config({Section, Keyname}) ->
+    IdleCheck = envy:get(sqerl, idle_check, 1000, non_neg_integer),
+    Statements = sqerl_config_env:read_statements_from_config(),
     {ok, Password} = chef_secrets:get(Section, Keyname),
-    [{pass, Password} | sqerl_config_env:config()].
+
+    %% The ip_mode key in the sqerl clause determines if we parse db_host as IPv4 or IPv6
+    [{host, envy_parse:host_to_ip(sqerl, db_host)},
+     {port, envy:get(sqerl, db_port, pos_integer)},
+     {user, envy:get(sqerl, db_user, string)},
+     {pass, Password},
+     {db, envy:get(sqerl, db_name, string)},
+     {extra_options, envy:get(sqerl, db_options, [], list)},
+     {timeout, envy:get(sqerl,db_timeout, 5000, pos_integer)},
+     {idle_check, IdleCheck},
+     {prepared_statements, Statements},
+     {column_transforms, envy:get(sqerl, column_transforms, list)}].

--- a/src/chef_secrets_sqerl.erl
+++ b/src/chef_secrets_sqerl.erl
@@ -10,17 +10,5 @@
 
 -spec config({binary(), binary()}) -> proplists:proplist().
 config({Section, Keyname}) ->
-    IdleCheck = envy:get(sqerl, idle_check, 1000, non_neg_integer),
-    Statements = sqerl_config_env:read_statements_from_config(),
     {ok, Password} = chef_secrets:get(Section, Keyname),
-
-    %% The ip_mode key in the sqerl clause determines if we parse db_host as IPv4 or IPv6
-    [{host, envy_parse:host_to_ip(sqerl, db_host)},
-     {port, envy:get(sqerl, db_port, pos_integer)},
-     {user, envy:get(sqerl, db_user, string)},
-     {pass, Password},
-     {db, envy:get(sqerl, db_name, string)},
-     {timeout, envy:get(sqerl,db_timeout, 5000, pos_integer)},
-     {idle_check, IdleCheck},
-     {prepared_statements, Statements},
-     {column_transforms, envy:get(sqerl, column_transforms, list)}].
+    [{pass, Password} | sqerl_config_env:config()].


### PR DESCRIPTION
…y overwrite pass instead of completely rebuilding the config

## Description

`sqerl` [was changed](https://github.com/chef/sqerl/pull/106) to add an optional `db_options` application configuration which allows additional options to be passed into the database driver initialization method.
However, `chef_secrets_sqerl:config` was not also updated to read the `db_options` configuration.
It probably should not need to be updated whenever new options are added to `sqerl_config_env:config`, but should instead call into that method and just replace the `pass` value with the loaded secret.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
