### PR TITLE
Zanecodes db options

### DIFF
--- a/src/chef_secrets_sqerl.erl
+++ b/src/chef_secrets_sqerl.erl
@@ -20,6 +20,7 @@ config({Section, Keyname}) ->
      {user, envy:get(sqerl, db_user, string)},
      {pass, Password},
      {db, envy:get(sqerl, db_name, string)},
+     {extra_options, envy:get(sqerl, db_options, [], list)},
      {timeout, envy:get(sqerl,db_timeout, 5000, pos_integer)},
      {idle_check, IdleCheck},
      {prepared_statements, Statements},


### PR DESCRIPTION
## Description
Earlier, sqerl was changed to add an optional db_options application configuration which allows additional options to be passed into the database driver initialization method.  However, chef_secrets_sqerl:config was never updated to read the additional db_options configuration.  This is the needed update to chef_secrets_sqerl:config.

This change is needed for:
https://github.com/chef/chef-server/pull/1711

We would like to thank zanecodes and Relativity for their contribution to this effort:
https://github.com/chef/chef_secrets/pull/26

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
