### PR TITLE
Exclude bin/setup and bin/console from the gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (13.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -60,4 +60,4 @@ DEPENDENCIES
   veil!
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/veil.gemspec
+++ b/veil.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/chef_secrets/"
 
   spec.files         = Dir.glob("{bin,lib,spec}/**/*").reject { |f| File.directory?(f) } + ["LICENSE"]
-  spec.executables   = spec.files.grep(/^bin/) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(/^bin/) { |f| File.basename(f) }.reject { |f| %w(setup console).include?(f) }
   spec.test_files    = spec.files.grep(/^(spec|features)/)
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
These are common names and easily conflict with other gems. They're only
for local use, no need to ship them.
    
```
ERROR:  Error installing veil-0.3.0.gem:
        "console" from veil conflicts with installed executable from wisper
```

Also bumped rake to clear the security alert.