### PR TITLE
CHEF-27646 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright © 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,6 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2017 Chef Software, Inc
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -166,3 +166,7 @@ redistribute /etc/opscode/private-chef-secrets.json:
   Please copy /etc/opscode/private-chef-secrets.json to each Chef Server and
   run 'chef-server-ctl reconfigure'
   ```
+  
+# Copyright
+
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/src/chef_secrets_env.erl
+++ b/src/chef_secrets_env.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2017, Chef Software, Inc
+%%% @Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%% @doc
 %%%
 %%% @end

--- a/src/chef_secrets_fd.erl
+++ b/src/chef_secrets_fd.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2017, Chef Software, Inc
+%%% @Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%% @doc
 %%%
 %%% @end

--- a/src/chef_secrets_json_file.erl
+++ b/src/chef_secrets_json_file.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2017, Chef Software, Inc
+%%% @Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%% @doc
 %%%
 %%% @end

--- a/src/chef_secrets_keyring.erl
+++ b/src/chef_secrets_keyring.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2017, Chef Software, Inc
+%%% @Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%% @doc
 %%%
 %%% @end

--- a/src/chef_secrets_mock.erl
+++ b/src/chef_secrets_mock.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2017, Chef Software, Inc
+%%% @Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%% @doc
 %%%
 %%% @end

--- a/src/chef_secrets_sqerl.erl
+++ b/src/chef_secrets_sqerl.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @copyright (C) 2017, Chef Software, Inc
+%%% @Copyright (c) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 %%% @doc
 %%%
 %%% @end


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2017-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `LICENSE:189` - Copyright in LICENSE file (move to COPYRIGHT)
- `README.md:1` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
